### PR TITLE
chore: adopt claude-harness plugin marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "claude-harness": {
+      "source": { "source": "github", "repo": "vveliev/claude-harness" }
+    }
+  },
+  "enabledPlugins": {
+    "fleet-harness@claude-harness": true
+  }
+}


### PR DESCRIPTION
Adds the claude-harness plugin stanza to `.claude/settings.json`: shared Claude Code skills (codebase-design, research) now come from the fleet-harness plugin in [vveliev/claude-harness](https://github.com/vveliev/claude-harness) and auto-install when the project is trusted — no vendored copies, nothing to drift. Decision: skynet ADR-0007 (vveliev/skynet#28); adoption tracked by `make scan-harness` in skynet. One identical one-file PR per fleet repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)