### PR TITLE
fix(ci): stop the weekly ci-init failure and clear the Node 20 deprecation

### DIFF
--- a/.github/workflows/aws-terraform-plan-apply.yml
+++ b/.github/workflows/aws-terraform-plan-apply.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/aws-tofu-plan-apply.yml
+++ b/.github/workflows/aws-tofu-plan-apply.yml
@@ -58,7 +58,7 @@ jobs:
       TF_VAR_version_tag: ${{ inputs.version_tag }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup tofu
         uses: opentofu/setup-opentofu@v1

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -68,7 +68,7 @@ jobs:
   build-and-push:
     runs-on: ${{ fromJson(inputs.runs-on) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Login to docker registry

--- a/.github/workflows/ci-autoupdate-github-action.yml
+++ b/.github/workflows/ci-autoupdate-github-action.yml
@@ -21,7 +21,7 @@ jobs:
     name: autoupdate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run GitHub Actions Version Updater
         uses: saadmk11/github-actions-version-updater@v0.8.1

--- a/.github/workflows/ci-autoupdate-precommit.yml
+++ b/.github/workflows/ci-autoupdate-precommit.yml
@@ -20,9 +20,9 @@ jobs:
   auto-update-pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
 
       - uses: browniebroke/pre-commit-autoupdate-action@main
 

--- a/.github/workflows/ci-github-pr-lable-size.yml
+++ b/.github/workflows/ci-github-pr-lable-size.yml
@@ -17,7 +17,7 @@ jobs:
   update-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-ecosystem/action-size@v2
         id: size
       - uses: actions-ecosystem/action-remove-labels@v1

--- a/.github/workflows/ci-github-pr-title-conventional-commit.yml
+++ b/.github/workflows/ci-github-pr-title-conventional-commit.yml
@@ -38,8 +38,8 @@ jobs:
   conventional-commits-pr-title-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 16
       - uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/ci-init.yml
+++ b/.github/workflows/ci-init.yml
@@ -3,12 +3,14 @@
 ---
 name: ci repo initializer
 
+# workflow_call only. This is a building block other workflows call, not
+# something to run on its own: every job below reads `inputs`, and the
+# `inputs` context is populated only for workflow_call. On a schedule or
+# workflow_dispatch trigger `inputs.runs-on` is the empty string, so
+# `fromJson('')` fails to parse and the run dies at startup with no jobs
+# and no log — which is what the weekly cron did every Sunday. Running it
+# standalone would only upload the repository to itself as an artifact.
 'on':
-  # every day at midnight
-  schedule:
-    - cron: 0 0 * * 0
-    # on demand
-  workflow_dispatch: null
   workflow_call:
     inputs:
       artifact_name:
@@ -45,14 +47,14 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: get version
         id: version
         run: |
           echo "version=$(git describe --tags --always)" >> $GITHUB_OUTPUT
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ inputs.artifact_upload }}
         with:
           name: ${{ inputs.artifact_name }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -34,8 +34,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
       - name: Set up Dart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     name: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
## Why

Two **scheduled** workflows have failed every Sunday since at least 2026-07-26. The repo's actual pull-request CI (`pre-commit`, `Size`) is green, so these were only visible on the Actions tab.

## `ci repo initializer` — real bug, fixed here

The run recorded **zero jobs and no log**: it died at workflow-parse time.

`ci-init.yml` declared `schedule` and `workflow_dispatch` alongside `workflow_call`, but every job reads the `inputs` context — which is populated **only** for `workflow_call`. On the cron trigger `inputs.runs-on` is the empty string, so `runs-on: ${{ fromJson(inputs.runs-on) }}` fails to parse. Every failure date is a Sunday, matching `cron: 0 0 * * 0`.

Fix: drop the two triggers. This is a building block other workflows call; running it standalone would only upload the repository to itself as an artifact, so removing the triggers is truer than giving the expression a fallback.

`build-docker.yml` uses the same `fromJson(inputs.runs-on)` pattern but is already `workflow_call`-only and was never affected — checked, not assumed.

## Node 20 deprecation

Bumped to the **minimum majors that actually run on Node 24**, verified against each action's `runs.using` rather than taken as the latest tag:

| Action | Change | Note |
|---|---|---|
| `actions/checkout` | v4 → v5 | v4 is node20 |
| `actions/setup-python` | v5 → v6 | v5 is node20 |
| `actions/setup-node` | v4 → v5 | v4 is node20 |
| `actions/upload-artifact` | v4 → **v6** | v5 is *still* node20 |

## Not addressed — both need a decision, not a bump

- **`actions-ecosystem/action-size@v2`, `action-add-labels@v1`, `action-remove-labels@v1`** still target Node 20. Last releases were 2020 and 2021 — there is no newer version. Clearing their warning means *replacing* the actions, which is a design call rather than a version bump.
- **`auto-update pre-commit`** fails on `##[error]GitHub Actions is not permitted to create or approve pull requests`. That is Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests". It is probably also why these pins drifted in the first place: both dependabot and `saadmk11/github-actions-version-updater` are configured here, and both need that same permission to land a bump.

## Verification

`actionlint 1.7.7` passes on all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)